### PR TITLE
Dependency fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -140,10 +140,12 @@
                     <groupId>commons-codec</groupId>
                     <artifactId>commons-codec</artifactId>
                 </exclusion>
+                <!--
                 <exclusion>
                     <groupId>org.apache.httpcomponents</groupId>
                     <artifactId>httpclient</artifactId>
                 </exclusion>
+                -->
             </exclusions>
         </dependency>
         
@@ -167,6 +169,12 @@
             <groupId>eu.clarin.weblicht</groupId>
             <artifactId>wlfxb</artifactId>
             <version>1.3.1</version>
+            <exclusions>                
+                <exclusion>
+                    <groupId>eu.clarin.weblicht</groupId>
+                    <artifactId>oaipmh-cmdi-bindings</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>eu.clarin.weblicht</groupId>
@@ -174,12 +182,28 @@
             <version>1.1.8</version>
             <exclusions>
                 <exclusion>
-                    <groupId>com.sun.jersey</groupId>
+                    <groupId>org.glassfish.jersey.core</groupId>
                     <artifactId>jersey-core</artifactId>
                 </exclusion>
                 <exclusion>
-                    <groupId>com.sun.jersey</groupId>
+                    <groupId>org.glassfish.jersey.core</groupId>
                     <artifactId>jersey-client</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>javax.xml.bind</groupId>
+                    <artifactId>jaxb-api</artifactId>
+                </exclusion>                    
+                <exclusion>
+                    <groupId>org.glassfish.hk2</groupId>
+                    <artifactId>hk2-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.glassfish.hk2</groupId>
+                    <artifactId>hk2-locator</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.glassfish.jersey.media</groupId>
+                    <artifactId>jersey-media-jax</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
@@ -199,6 +223,10 @@
                     <groupId>com.google.guava</groupId>
                     <artifactId>guava</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 
@@ -206,6 +234,12 @@
             <groupId>org.apache.poi</groupId>
             <artifactId>poi-ooxml</artifactId>
             <version>3.17</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-codec</groupId>
+                    <artifactId>commons-codec</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- Using it from jersey-apache-client4 instead -->        
@@ -217,7 +251,7 @@
                 <type>jar</type>
         </dependency>
 -->
-    
+    <!--
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
@@ -229,6 +263,7 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        -->
         <!-- dropwizard 0.8 uses commons-lang3, changed imports -->
         <!--dependency>
           <groupId>commons-lang</groupId>
@@ -238,29 +273,9 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.6</version>
+            <version>3.9</version>
         </dependency>
-<!--        
-        <dependency>
-            <groupId>com.sun.jersey.contribs</groupId>
-            <artifactId>jersey-apache-client4</artifactId>
-            <version>1.19.4</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.apache.httpcomponents</groupId>
-                    <artifactId>httpclient</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.sun.jersey</groupId>
-                    <artifactId>jersey-core</artifactId>
-                </exclusion>
-                <exclusion>
-                        <groupId>com.sun.jersey</groupId>
-                        <artifactId>jersey-client</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
--->
+
         <dependency>
             <groupId>org.jopendocument</groupId>
             <artifactId>jOpenDocument</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -203,7 +203,7 @@
                 </exclusion>
                 <exclusion>
                     <groupId>org.glassfish.jersey.media</groupId>
-                    <artifactId>jersey-media-jax</artifactId>
+                    <artifactId>jersey-media-jaxb</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/src/main/resources/assets/js/pages/helppage.jsx
+++ b/src/main/resources/assets/js/pages/helppage.jsx
@@ -45,7 +45,7 @@ var HelpPage = createReactClass({
 
 					<h3>More help</h3>
 					<p>More detailed information on using FCS Aggregator is available at the &nbsp;
-					<a href="http://weblicht.sfs.uni-tuebingen.de/weblichtwiki/index.php/FCS_Aggregator">
+					<a href="https://www.clarin.eu/content/content-search-tutorial">
 						Aggregator wiki page
 					</a>.
 					If you still cannot find an answer to your question,


### PR DESCRIPTION
* Resolved some dependency clashes as reported by the maven enforcer plugin. I have resolved these as much as possible by excluding the oldest versions from dependencies.
* Updated the link to the tutorial page as requested by Dieter

This version has been compiled (https://gitlab.com/CLARIN-ERIC/docker-fcs/-/tags/1.1.0-openjdk11) and deployed at https://fcs.clarin-dev.eu for testing purposes