### PR TITLE
Weblicht connector update

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -179,7 +179,7 @@
         <dependency>
             <groupId>eu.clarin.weblicht</groupId>
             <artifactId>connectors</artifactId>
-            <version>1.1.8</version>
+            <version>2.0.1</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.glassfish.jersey.core</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <serviceUser>aggregator</serviceUser>
         <serviceGroup>aggregator</serviceGroup>
-        <version.dropwizard>2.0.0</version.dropwizard>
+        <version.dropwizard>2.0.3</version.dropwizard>
     </properties>
 
     <repositories>


### PR DESCRIPTION
The weblicht connector library has been update to offer compatibility with a new version of the centre registry. This update in the centre registry will break existing clients. Please update and deploy the FCS with this new version of the weblicht connector library.