### PR TITLE
Disable mouse interaction for hidden remove buttons in FCS-QL query builder

### DIFF
--- a/src/main/resources/assets/adv.css
+++ b/src/main/resources/assets/adv.css
@@ -1,6 +1,6 @@
 .query_token:only-of-type .close_btn {
 	opacity: 0;
-	cursor: default;
+	pointer-events: none;
 	transition: opacity 200ms ease;
 }
 
@@ -94,7 +94,7 @@
 }
 
 .query_arg:only-of-type .or_arg:only-child .remove_arg {
-	cursor: default;
+	pointer-events: none;
 	opacity: 0;
 	transition: opacity 200ms ease;
 }


### PR DESCRIPTION
The query builder for FCS-QL queries hides the remove buttons for OR/AND query tokens but a mouse click will still remove the entities. This can result in invalid query states.
Using `pointer-events: none`, mouse interaction (clicks) will be blocked. (The `cursor: default` will be ignored, so I removed it.)
Supported in most browsers: https://caniuse.com/pointer-events