### PR TITLE
Add advanced layer grouping by search hit

### DIFF
--- a/src/main/java/eu/clarin/sru/fcs/aggregator/search/Exports.java
+++ b/src/main/java/eu/clarin/sru/fcs/aggregator/search/Exports.java
@@ -88,7 +88,8 @@ public class Exports {
 			    }
 			}
 			firstRow = true;
-			for (AdvancedLayer layer : result.getAdvancedLayers()) {
+			for (List<AdvancedLayer> layers : result.getAdvancedLayers()) {
+		    for (AdvancedLayer layer : layers) {
 			    if (firstRow) {
 				String[] headers = new String[]{
 				    "PID", "REFERENCE", "SPANS"};
@@ -125,6 +126,7 @@ public class Exports {
 			    }
 			    csv.append("\n");
 			    noResult = false;
+			}
 			}
 		    }
 		}
@@ -205,7 +207,8 @@ public class Exports {
 			    cell.setCellValue(kwic.getRight());
 			}
 		    }
-		    for (AdvancedLayer layer : result.getAdvancedLayers()) {
+			for (List<AdvancedLayer> layers : result.getAdvancedLayers()) {
+		    for (AdvancedLayer layer : layers) {
 			if (firstRow) {
 			    String[] headers = new String[]{
 				"PID", "REFERENCE", "SPANS"};
@@ -241,6 +244,7 @@ public class Exports {
 			    j++;
 			}
 		    }
+			}
 		}
 		workbook.write(excelStream);
 	    } catch (IOException ex) {
@@ -310,8 +314,13 @@ public class Exports {
 			firstRow = false;
 		    }
 
-		    sheet.ensureRowCount(rownum + result.getAdvancedLayers().size() + 2);
-		    for (AdvancedLayer layer : result.getAdvancedLayers()) {
+			int numAdvancedLayers = 0;
+			for (List<AdvancedLayer> layers : result.getAdvancedLayers()) {
+				numAdvancedLayers += layers.size();
+			}
+		    sheet.ensureRowCount(rownum + numAdvancedLayers + 2);
+			for (List<AdvancedLayer> layers : result.getAdvancedLayers()) {
+		    for (AdvancedLayer layer : layers) {
 			if (filterLanguage != null && !filterLanguage.equals(layer.getLanguage())) {
 			    continue;
 			}
@@ -336,6 +345,7 @@ public class Exports {
 			    j++;
 			}
 		    }
+			}
 		}
 	    }
 	    try {

--- a/src/main/java/eu/clarin/sru/fcs/aggregator/search/Result.java
+++ b/src/main/java/eu/clarin/sru/fcs/aggregator/search/Result.java
@@ -48,13 +48,13 @@ public final class Result {
 	private List<Diagnostic> diagnostics = Collections.synchronizedList(new ArrayList<Diagnostic>());
 	private List<Kwic> kwics = Collections.synchronizedList(new ArrayList<Kwic>());
 
-	private List<AdvancedLayer> advLayers = Collections.synchronizedList(new ArrayList<AdvancedLayer>());
+	private List<List<AdvancedLayer>> advLayers = Collections.synchronizedList(new ArrayList<List<AdvancedLayer>>());
 
 	public List<Kwic> getKwics() {
 		return kwics;
 	}
 
-	public List<AdvancedLayer> getAdvancedLayers() {
+	public List<List<AdvancedLayer>> getAdvancedLayers() {
 		return advLayers;
 	}
 
@@ -144,11 +144,13 @@ public final class Result {
 				log.debug("DataViewHits: {}", kwic.getFragments());
 			} else if (dataview instanceof DataViewAdvanced) {
 				final DataViewAdvanced adv = (DataViewAdvanced) dataview;
+				List<AdvancedLayer> advLayersSingleGroup = new ArrayList<>();
 				for (DataViewAdvanced.Layer layer : adv.getLayers()) {
 				    log.debug("DataViewAdvanced layer: {}", 				adv.getUnit(), layer.getId());
 				    AdvancedLayer aLayer = new AdvancedLayer(layer, pid, reference);
-				    advLayers.add(aLayer);
+					advLayersSingleGroup.add(aLayer);
 				}
+				advLayers.add(advLayersSingleGroup);
 			}
 		}
 	}

--- a/src/main/resources/assets/base.css
+++ b/src/main/resources/assets/base.css
@@ -409,6 +409,14 @@ div.popover {
 	max-width:552px;
 }
 
+.panel-body .table.advanced-layers > tbody > tr.hitrow-sep {
+	border-bottom: 1px solid #ddd;
+}
+
+.panel-body .table.advanced-layers > tbody > tr.hitrow-sep > td {
+	padding: 0;
+}
+
 /*** zoomed result ***/
 
 .modal-body .corpusDescription {

--- a/src/main/resources/assets/js/components/resultmixin.jsx
+++ b/src/main/resources/assets/js/components/resultmixin.jsx
@@ -76,6 +76,20 @@ var ResultMixin = {
 	           </tr>);
 	},
 
+	renderRowsAsADVGrouped: function (corpusHit) {
+		function renderWithSeperators (layers, i) {
+			var pre = (i != 0) ? [(
+				<tr class="hitrow-sep"><td colspan="100%" /></tr>
+			)] : [];
+			return pre.concat(layers.map(this.renderRowsAsADV));
+		}
+		function renderPlainList(layers, i) {
+			return layers.map(this.renderRowsAsADV);
+		}
+		var needsSeparators = Math.min(...corpusHit.advancedLayers.map(x => x.length)) > 1;
+		return corpusHit.advancedLayers.map((needsSeparators ? renderWithSeperators : renderPlainList).bind(this));
+	},
+
 	renderDiagnostic: function(d, key) {
 		if (d.uri === window.MyAggregator.NO_MORE_RECORDS_DIAGNOSTIC_URI) {
 			return false;
@@ -112,15 +126,15 @@ var ResultMixin = {
 		return 	(<div>
 			    {this.renderErrors(corpusHit)}
 			    {this.renderDiagnostics(corpusHit)}
-			    <table className="table table-condensed table-hover" style={fulllength}>
-				<tbody>{corpusHit.advancedLayers.map(this.renderRowsAsADV)}</tbody>
+			    <table className="table table-condensed table-hover advanced-layers" style={fulllength}>
+				<tbody>{this.renderRowsAsADVGrouped(corpusHit)}</tbody>
 			    </table>
 		</div>);
 	    } else if (this.state.displayKwic) {
 		return 	(<div>
 		    {this.renderErrors(corpusHit)}
 		    {this.renderDiagnostics(corpusHit)}
-		    <table className="table table-condensed table-hover" style={fulllength}>
+		    <table className="table table-condensed table-hover kwic" style={fulllength}>
 			<tbody>{corpusHit.kwics.map(this.renderRowsAsKwic)}</tbody>
 		    </table>
 		</div>);

--- a/src/main/resources/assets/js/main.js
+++ b/src/main/resources/assets/js/main.js
@@ -49751,6 +49751,8 @@ var _propTypes2 = _interopRequireDefault(_propTypes);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
+function _toConsumableArray(arr) { if (Array.isArray(arr)) { for (var i = 0, arr2 = Array(arr.length); i < arr.length; i++) { arr2[i] = arr[i]; } return arr2; } else { return Array.from(arr); } }
+
 var PT = _propTypes2.default;
 
 window.MyAggregator = window.MyAggragtor || {};
@@ -49875,6 +49877,24 @@ var ResultMixin = {
 		);
 	},
 
+	renderRowsAsADVGrouped: function renderRowsAsADVGrouped(corpusHit) {
+		function renderWithSeperators(layers, i) {
+			var pre = i != 0 ? [React.createElement(
+				"tr",
+				{ "class": "hitrow-sep" },
+				React.createElement("td", { colspan: "100%" })
+			)] : [];
+			return pre.concat(layers.map(this.renderRowsAsADV));
+		}
+		function renderPlainList(layers, i) {
+			return layers.map(this.renderRowsAsADV);
+		}
+		var needsSeparators = Math.min.apply(Math, _toConsumableArray(corpusHit.advancedLayers.map(function (x) {
+			return x.length;
+		}))) > 1;
+		return corpusHit.advancedLayers.map((needsSeparators ? renderWithSeperators : renderPlainList).bind(this));
+	},
+
 	renderDiagnostic: function renderDiagnostic(d, key) {
 		if (d.uri === window.MyAggregator.NO_MORE_RECORDS_DIAGNOSTIC_URI) {
 			return false;
@@ -49931,11 +49951,11 @@ var ResultMixin = {
 				this.renderDiagnostics(corpusHit),
 				React.createElement(
 					"table",
-					{ className: "table table-condensed table-hover", style: fulllength },
+					{ className: "table table-condensed table-hover advanced-layers", style: fulllength },
 					React.createElement(
 						"tbody",
 						null,
-						corpusHit.advancedLayers.map(this.renderRowsAsADV)
+						this.renderRowsAsADVGrouped(corpusHit)
 					)
 				)
 			);
@@ -49947,7 +49967,7 @@ var ResultMixin = {
 				this.renderDiagnostics(corpusHit),
 				React.createElement(
 					"table",
-					{ className: "table table-condensed table-hover", style: fulllength },
+					{ className: "table table-condensed table-hover kwic", style: fulllength },
 					React.createElement(
 						"tbody",
 						null,
@@ -51635,8 +51655,10 @@ var AggregatorPage = (0, _createReactClass2.default)({
 					kwics: noLangFiltering ? corpusHit.kwics : corpusHit.kwics.filter(function (kwic) {
 						return kwic.language === langCode || langCode === multipleLanguageCode || langCode === null;
 					}),
-					advancedLayers: noLangFiltering ? corpusHit.advancedLayers : corpusHit.advancedLayers.filter(function (layer) {
-						return layer.language === langCode || langCode === multipleLanguageCode || langCode === null;
+					advancedLayers: noLangFiltering ? corpusHit.advancedLayers : corpusHit.advancedLayers.filter(function (layers) {
+						return layers.every(function (layer) {
+							return layer.language === langCode || langCode === multipleLanguageCode || langCode === null;
+						});
 					})
 				};
 			});

--- a/src/main/resources/assets/js/pages/aggregatorpage.jsx
+++ b/src/main/resources/assets/js/pages/aggregatorpage.jsx
@@ -300,10 +300,12 @@ var AggregatorPage = createReactClass({
 							       langCode === null;
 						}),
 					advancedLayers: noLangFiltering ? corpusHit.advancedLayers :
-					 	corpusHit.advancedLayers.filter(function(layer) {
-					 		return layer.language === langCode ||
-					 		       langCode === multipleLanguageCode ||
-					 		       langCode === null;
+					 	corpusHit.advancedLayers.filter(function(layers) {
+							return layers.every(function(layer) {
+								return layer.language === langCode ||
+									langCode === multipleLanguageCode ||
+									langCode === null;
+							});
 					 	}),
 				};
 			});


### PR DESCRIPTION
This introduces grouping of the AdvancedDataView layers in the frontend.
If an corpus/endpoint provides more than one layer for a single result then the layers will be grouped with a small, visible line. If all results of a corpus/endpoint only provide a single layer then no line is shown.

I'm a bit unsure how to test the `src/main/resources/assets/js/pages/aggregatorpage.jsx` code. Theoretically, it should be sound but a test might be good. Or console log outputs.
Exports seem to work fine.

<details>
  <summary>Examples</summary>

#### Example without line:
![grafik](https://user-images.githubusercontent.com/1648294/176925794-cf416044-4b6f-477f-b079-a7f2c055264b.png)

#### Example with line:
![grafik](https://user-images.githubusercontent.com/1648294/176925845-6a544dbb-1e11-4e8c-8641-ad5a069f6c91.png)
</details>