### PR TITLE
Fix collection description string

### DIFF
--- a/src/main/java/eu/clarin/sru/fcs/aggregator/scan/ScanCrawler.java
+++ b/src/main/java/eu/clarin/sru/fcs/aggregator/scan/ScanCrawler.java
@@ -189,7 +189,7 @@ public class ScanCrawler {
 			Corpus c = new Corpus(institution, endpoint);
 			c.setHandle(ri.getPid());
 			c.setTitle(getBestValueFrom(ri.getTitle()));
-			c.setDescription(getBestValueFrom(ri.getTitle()));
+			c.setDescription(getBestValueFrom(ri.getDescription()));
 			c.setLanguages(new HashSet<String>(ri.getLanguages()));
 			c.setLandingPage(ri.getLandingPageURI());
 

--- a/src/main/java/eu/clarin/sru/fcs/aggregator/scan/ScanCrawler.java
+++ b/src/main/java/eu/clarin/sru/fcs/aggregator/scan/ScanCrawler.java
@@ -189,7 +189,9 @@ public class ScanCrawler {
 			Corpus c = new Corpus(institution, endpoint);
 			c.setHandle(ri.getPid());
 			c.setTitle(getBestValueFrom(ri.getTitle()));
-			c.setDescription(getBestValueFrom(ri.getDescription()));
+			if (ri.getDescription() != null) {
+				c.setDescription(getBestValueFrom(ri.getDescription()));
+			}
 			c.setLanguages(new HashSet<String>(ri.getLanguages()));
 			c.setLandingPage(ri.getLandingPageURI());
 


### PR DESCRIPTION
Fix corpora resource handling. Use the correct collection description string.
Frontend (of local setup) shows title string instead of description.