### PR TITLE
Fix tab change on statistics page

### DIFF
--- a/src/main/resources/assets/js/main.js
+++ b/src/main/resources/assets/js/main.js
@@ -52683,8 +52683,10 @@ var StatisticsPage = (0, _createReactClass2.default)({
 		);
 	},
 
-	setTab: function setTab(idx) {
+	setTab: function setTab(idx, e) {
 		this.setState({ activeTab: idx });
+		e.preventDefault();
+		e.stopPropagation();
 	},
 
 	render: function render() {
@@ -52713,7 +52715,7 @@ var StatisticsPage = (0, _createReactClass2.default)({
 								{ role: "presentation", className: classname, key: st[0] },
 								React.createElement(
 									"a",
-									{ href: "#", role: "tab", onClick: this.setTab.bind(this, idx) },
+									{ href: "#", title: st[0], role: "tab", onClick: this.setTab.bind(this, idx) },
 									st[0]
 								)
 							);

--- a/src/main/resources/assets/js/pages/statisticspage.jsx
+++ b/src/main/resources/assets/js/pages/statisticspage.jsx
@@ -155,8 +155,10 @@ var StatisticsPage = createReactClass({
 				 ;
 	},
 
-	setTab: function(idx) {
+	setTab: function(idx, e) {
 		this.setState({activeTab:idx});
+		e.preventDefault();
+		e.stopPropagation();
 	},
 
 	render: function() {
@@ -170,7 +172,7 @@ var StatisticsPage = createReactClass({
 							{ _.pairs(this.state.stats).map(function(st, idx){
 									var classname = idx === this.state.activeTab ? "active":"";
 									return 	<li role="presentation" className={classname} key={st[0]}>
-												<a href="#" role="tab" onClick={this.setTab.bind(this, idx)}>{st[0]}</a>
+												<a href="#" title={st[0]} role="tab" onClick={this.setTab.bind(this, idx)}>{st[0]}</a>
 											</li>;
 								}.bind(this))
 							}


### PR DESCRIPTION
Fix tab change on the statistics page. Disable mouse event to avoid redirection.