### PR TITLE
Add corpus grouping in corpusview modal

### DIFF
--- a/src/main/resources/assets/base.css
+++ b/src/main/resources/assets/base.css
@@ -231,6 +231,7 @@ div.corpus-container {
 	border-bottom: 1px solid #eee;
 }
 div.corpusview-institutions > div.corpusview-corpora:hover,
+div.corpusview-languages > div.corpusview-corpora:hover,
 div.corpus-container:hover {
 	box-shadow: 0 0 10px rgb(179,216,253) !important;
 }

--- a/src/main/resources/assets/base.css
+++ b/src/main/resources/assets/base.css
@@ -230,12 +230,23 @@ div.corpus-container {
 	margin: 5px 0;
 	border-bottom: 1px solid #eee;
 }
+div.corpusview-institutions > div.corpusview-corpora:hover,
 div.corpus-container:hover {
 	box-shadow: 0 0 10px rgb(179,216,253) !important;
 }
 div.corpus-container.dimmed {
 	/*font-weight: 300;*/
 	/*opacity: 0.8;*/
+}
+
+div.corpusview-corpora > h3 {
+	padding-top: 0.5em;
+	padding-left: 0.5em;
+}
+
+div.corpusview-corpora > div.expansion-handle {
+	padding-bottom: 0.5em;
+	padding-left: 0.5em;
 }
 
 div.modal-dialog input {
@@ -285,6 +296,7 @@ div.corpus p {
 	margin: 5px 0;
 }
 
+div.corpusview-corpora div.expansion-handle,
 div.corpus div.expansion-handle {
 	margin: 0 0 5px 0;
 	cursor: pointer;

--- a/src/main/resources/assets/js/components/corpusview.jsx
+++ b/src/main/resources/assets/js/components/corpusview.jsx
@@ -92,6 +92,12 @@ var CorpusView = createReactClass({
 		this.props.corpora.update();
 	},
 
+	selectAllFromList: function (corpora, value) {
+		// like selectAll(), just for list of corpora
+		this.props.corpora.recurseCorpora(corpora, function (c) { c.visible ? c.selected = value : false });
+		this.props.corpora.update();
+	},
+
 	selectAllShown: function (value) {
 		// select only visible/shown corpora, i.e. corpora that are shown in dialog, possibly filtered due to query
 		this.props.corpora.recurse(function (c) { c.visible && c.priority > 0 ? c.selected = value : false });
@@ -227,6 +233,15 @@ var CorpusView = createReactClass({
 		</div>;
 	},
 
+	renderSelectionButtonsGrouped: function (corpora) {
+		return (<div className="float-right inline" style={{ paddingTop: "1.5em" }}>
+			<button className="btn btn-default" style={{ marginRight: 10 }} onClick={this.selectAllFromList.bind(this, corpora, true)}>
+				{" Select all"}</button>
+			<button className="btn btn-default" style={{ marginRight: 20 }} onClick={this.selectAllFromList.bind(this, corpora, false)}>
+				{" Deselect all"}</button>
+		</div>);
+	},
+
 	renderLanguages: function(languages) {
 		return languages
 				.map(function(l) { return this.props.languageMap[l]; }.bind(this))
@@ -352,6 +367,7 @@ var CorpusView = createReactClass({
 			});
 			if (corpListRender.length > 0) {
 				groupedListRender.push(<div className="corpusview-corpora">
+					{this.renderSelectionButtonsGrouped(groupedCorpora.corpora)}
 					<h3 style={{ paddingTop: "0.5em" }}><i class="fa fa-institution"/> {institution}</h3>
 					{this.renderExpansionGrouped(groupedCorpora)}
 					{groupedCorpora.expanded ? corpListRender : false}

--- a/src/main/resources/assets/js/components/corpusview.jsx
+++ b/src/main/resources/assets/js/components/corpusview.jsx
@@ -50,6 +50,12 @@ var CorpusView = createReactClass({
 		this.props.corpora.update();
 	},
 
+	selectAllShown: function (value) {
+		// select only visible/shown corpora, i.e. corpora that are shown in dialog, possibly filtered due to query
+		this.props.corpora.recurse(function (c) { c.visible && c.priority > 0 ? c.selected = value : false });
+		this.props.corpora.update();
+	},
+
 	searchCorpus: function(query) {
 		// sort fn: descending priority, stable sort
 		var sortFn = function(a, b){
@@ -307,6 +313,8 @@ var CorpusView = createReactClass({
 						<div className="float-right inline">
 							<button className="btn btn-default" style={{ marginRight: 10 }} onClick={this.selectAll.bind(this,true)}>
 								{" Select all"}</button>
+							<button className="btn btn-default" style={{ marginRight: 10 }} onClick={this.selectAllShown.bind(this, true)}>
+								{" Select visible"}</button>
 							<button className="btn btn-default" style={{ marginRight: 20 }} onClick={this.selectAll.bind(this,false)}>
 								{" Deselect all"}</button>
 						</div>

--- a/src/main/resources/assets/js/main.js
+++ b/src/main/resources/assets/js/main.js
@@ -47795,6 +47795,14 @@ var CorpusView = (0, _createReactClass2.default)({
 		this.props.corpora.update();
 	},
 
+	selectAllFromList: function selectAllFromList(corpora, value) {
+		// like selectAll(), just for list of corpora
+		this.props.corpora.recurseCorpora(corpora, function (c) {
+			c.visible ? c.selected = value : false;
+		});
+		this.props.corpora.update();
+	},
+
 	selectAllShown: function selectAllShown(value) {
 		// select only visible/shown corpora, i.e. corpora that are shown in dialog, possibly filtered due to query
 		this.props.corpora.recurse(function (c) {
@@ -47947,6 +47955,23 @@ var CorpusView = (0, _createReactClass2.default)({
 				", ",
 				selectedCount,
 				" (sub)collections selected)"
+			)
+		);
+	},
+
+	renderSelectionButtonsGrouped: function renderSelectionButtonsGrouped(corpora) {
+		return React.createElement(
+			"div",
+			{ className: "float-right inline", style: { paddingTop: "1.5em" } },
+			React.createElement(
+				"button",
+				{ className: "btn btn-default", style: { marginRight: 10 }, onClick: this.selectAllFromList.bind(this, corpora, true) },
+				" Select all"
+			),
+			React.createElement(
+				"button",
+				{ className: "btn btn-default", style: { marginRight: 20 }, onClick: this.selectAllFromList.bind(this, corpora, false) },
+				" Deselect all"
 			)
 		);
 	},
@@ -48125,6 +48150,7 @@ var CorpusView = (0, _createReactClass2.default)({
 				groupedListRender.push(React.createElement(
 					"div",
 					{ className: "corpusview-corpora" },
+					_this3.renderSelectionButtonsGrouped(groupedCorpora.corpora),
 					React.createElement(
 						"h3",
 						{ style: { paddingTop: "0.5em" } },

--- a/src/main/resources/assets/js/main.js
+++ b/src/main/resources/assets/js/main.js
@@ -47750,6 +47750,14 @@ var CorpusView = (0, _createReactClass2.default)({
 		this.props.corpora.update();
 	},
 
+	selectAllShown: function selectAllShown(value) {
+		// select only visible/shown corpora, i.e. corpora that are shown in dialog, possibly filtered due to query
+		this.props.corpora.recurse(function (c) {
+			c.visible && c.priority > 0 ? c.selected = value : false;
+		});
+		this.props.corpora.update();
+	},
+
 	searchCorpus: function searchCorpus(query) {
 		// sort fn: descending priority, stable sort
 		var sortFn = function sortFn(a, b) {
@@ -48060,6 +48068,11 @@ var CorpusView = (0, _createReactClass2.default)({
 						"button",
 						{ className: "btn btn-default", style: { marginRight: 10 }, onClick: this.selectAll.bind(this, true) },
 						" Select all"
+					),
+					React.createElement(
+						"button",
+						{ className: "btn btn-default", style: { marginRight: 10 }, onClick: this.selectAllShown.bind(this, true) },
+						" Select visible"
 					),
 					React.createElement(
 						"button",


### PR DESCRIPTION
Add grouping of corpora/resources in `corpusview` modal.
- add grouping by institution (name, not endpoint)
- add grouping by language (single language, combinations will be split, so one resource might appear multiple times but (de-)selection will be sync'd)
- add buttons to select only visible (as in shown in modal) corpora, so users can deselect all, type in some query in the modal to restrict them and only select the shown corpora for searching